### PR TITLE
Fix JSON example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $json = <<<JSON
     },
     "name": {
       "type": "string"
-    },
+    }
   },
   "required": ["id", "name"]
 }


### PR DESCRIPTION
There is a leading comma breaking the JSON decoding